### PR TITLE
Replacing share() by singleton() in provider

### DIFF
--- a/src/Facade/Parser.php
+++ b/src/Facade/Parser.php
@@ -8,5 +8,5 @@ class Parser extends Facade {
     /**
      * {@inheritDocs}
      */
-    protected static function getFacadeAccessor() { return 'browser-detect.parser'; }
+    protected static function getFacadeAccessor() {  return \hisorange\BrowserDetect\Parser::class; }
 }

--- a/src/Provider/BrowserDetectService.php
+++ b/src/Provider/BrowserDetectService.php
@@ -45,9 +45,9 @@ class BrowserDetectService extends ServiceProvider {
 	 */
 	public function registerParser()
 	{
-		$this->app->singleton('browser-detect.parser',function($app) {
-			return new Parser($app);
-		});
+		$this->app->singleton(Parser::class, function($app) {
+            return new Parser($app);
+        });
 	}
 
 	/**
@@ -68,7 +68,7 @@ class BrowserDetectService extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return ['browser-detect.parser', 'browser-detect.result'];
+		 return [Parser::class, 'browser-detect.result'];
 	}
 
 }


### PR DESCRIPTION
In version laravel 5.4 the share() method is replaced by singleton()