### PR TITLE
Upgrade phpleague/pipeline dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,12 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
-  - LARAVEL_VERSION=5.0
-  - LARAVEL_VERSION=5.1
-  - LARAVEL_VERSION=5.2
-  - LARAVEL_VERSION=5.3
-  - LARAVEL_VERSION=5.4
-  - LARAVEL_VERSION=5.5
-  - LARAVEL_VERSION=5.6
-
-matrix:
-  exclude:
-    - php: 5.6
-      env: LARAVEL_VERSION=5.5
-    - php: 5.6
-      env: LARAVEL_VERSION=5.6
-    - php: 7.0
-      env: LARAVEL_VERSION=5.0
-    - php: 7.0
-      env: LARAVEL_VERSION=5.1
-    - php: 7.0
-      env: LARAVEL_VERSION=5.2
-    - php: 7.0
-      env: LARAVEL_VERSION=5.3
-    - php: 7.0
-      env: LARAVEL_VERSION=5.6
-    - php: 7.1
-      env: LARAVEL_VERSION=5.0
-    - php: 7.1
-      env: LARAVEL_VERSION=5.1
-    - php: 7.1
-      env: LARAVEL_VERSION=5.2
-    - php: 7.1
-      env: LARAVEL_VERSION=5.3
-    - php: 7.1
-      env: LARAVEL_VERSION=5.4
-    - php: 7.2
-      env: LARAVEL_VERSION=5.0
-    - php: 7.2
-      env: LARAVEL_VERSION=5.1
-    - php: 7.2
-      env: LARAVEL_VERSION=5.2
-    - php: 7.2
-      env: LARAVEL_VERSION=5.3
-    - php: 7.2
-      env: LARAVEL_VERSION=5.4
+  - LARAVEL_VERSION=5.8
 
 before_install:
   - composer self-update >/dev/null 2>&1

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
         "laravel/framework": "~5.0",
         "ua-parser/uap-php": "~3.8",
-        "league/pipeline": "~0.1",
+        "league/pipeline": "~1.0",
         "mobiledetect/mobiledetectlib": "~2.0",
         "jaybizzle/crawler-detect": "~1.0",
         "piwik/device-detector": "~3.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.1.3",
         "laravel/framework": "~5.0",
         "ua-parser/uap-php": "~3.8",
         "league/pipeline": "~1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          bootstrap="./vendor/autoload.php"
-         strict="true"
          verbose="true"
          colors="true"
 >

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -111,13 +111,12 @@ class Parser implements ParserInterface
      */
     protected function process($agent)
     {
-        $pipeline = new Pipeline([
-            new Stages\UAParser,
-            new Stages\MobileDetect,
-            new Stages\CrawlerDetect,
-            new Stages\DeviceDetector,
-            new Stages\BrowserDetect,
-        ]);
+        $pipeline = (new Pipeline())
+            ->pipe(new Stages\UAParser)
+            ->pipe(new Stages\MobileDetect)
+            ->pipe(new Stages\CrawlerDetect)
+            ->pipe(new Stages\DeviceDetector)
+            ->pipe(new Stages\BrowserDetect);
 
         return $pipeline->process(new Payload($agent));
     }

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -16,7 +16,7 @@ class BladeTest extends TestCase
      * @throws \PHPUnit\Framework\SkippedTestError
      * @throws \PHPUnit_Framework_SkippedTestError
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
1. `league/pipeline` has a 1.0.0 release so this updates the dependency and updates the Pipeline call to be compatible.
2. Fixed phpunit `strict` warning: "The attribute 'strict' is not allowed." See [here](https://travis-ci.org/hisorange/browser-detect/jobs/478294677#L603)
3. The Testbench `setUp()` method now has a return type declaration `void` so I updated the test to add that.
4. Updated `travis.yml` to include only the currently supported versions of PHP and Laravel.

Would need to be a semver major version release because `pipeline` minimum requirement is PHP 7.1. The README would need to be updated to reflect the new minimum requirements.