### PR TITLE
Adding support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "~5.0",
+        "laravel/framework": "~5.0|^6.0",
         "ua-parser/uap-php": "~3.8",
         "league/pipeline": "~0.1",
         "mobiledetect/mobiledetectlib": "~2.0",
@@ -21,8 +21,8 @@
         "piwik/device-detector": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0 || ~6.0 || ~7.0",
-        "orchestra/testbench": "~3.0",
+        "phpunit/phpunit": "~5.0 || ~6.0 || ~7.0 || ~8.0",
+        "orchestra/testbench": "~3.0 || ^4.0",
         "satooshi/php-coveralls": "^1.0"
     },
     "autoload": {

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -16,7 +16,7 @@ class BladeTest extends TestCase
      * @throws \PHPUnit\Framework\SkippedTestError
      * @throws \PHPUnit_Framework_SkippedTestError
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,10 @@ use hisorange\BrowserDetect\ServiceProvider;
  */
 class TestCase extends \Orchestra\Testbench\TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
     /**
      * Register the service.
      *


### PR DESCRIPTION
With Laravel upgrade, all tests passed and enough to go ahead with Laravel 6 