### PR TITLE
Bump version 4.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
   ],
   "homepage": "https://github.com/hisorange/browser-detect",
   "license": "MIT",
-  "version": "4.2.2",
   "authors": [
     {
       "name": "Varga Zsolt (hisorange)",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "homepage": "https://github.com/hisorange/browser-detect",
   "license": "MIT",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "authors": [
     {
       "name": "Varga Zsolt (hisorange)",


### PR DESCRIPTION
The latest version 4.2.1 is not being picked up on https://packagist.org/packages/hisorange/browser-detect or when doing `composer update`
It appears that this relates to the version string in the `composer.json` file.