### PR TITLE
Drop version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
   ],
   "homepage": "https://github.com/hisorange/browser-detect",
   "license": "MIT",
-  "version": "4.2.0",
   "authors": [
     {
       "name": "Varga Zsolt (hisorange)",


### PR DESCRIPTION
Including the version in the `composer.json` causes a conflict if the version does not match the tag version, sometimes causing releases to be skipped