### PR TITLE
docs: removed unnecessary `is` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Easy peasy, ain't it?
 
 ---
 
-The following matrix is has been continuously tested by the great and awesome **GitHub Actions**!
+The following matrix has been continuously tested by the great and awesome **GitHub Actions**!
 
 |    -----     | Browser Detect 1.x | Browser Detect 2.x | Browser Detect 3.x | Browser Detect 4.x | Browser Detect 5.x |
 | :----------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |


### PR DESCRIPTION
Unnecessary `is` removed, to fix the readme grammatical issue.