### PR TITLE
fix: typo issue in BrowserDetect to detect Chrome browser

### DIFF
--- a/src/Stages/BrowserDetect.php
+++ b/src/Stages/BrowserDetect.php
@@ -55,7 +55,7 @@ class BrowserDetect implements StageInterface
         }
 
         // Popular browser vendors.
-        if (false !== stripos($payload->getValue('browserFamily') ?? '', 'chrom')) {
+        if (false !== stripos($payload->getValue('browserFamily') ?? '', 'chrome')) {
             $payload->setValue('isChrome', true);
         } elseif (false !== stripos($payload->getValue('browserFamily') ?? '', 'firefox')) {
             $payload->setValue('isFirefox', true);


### PR DESCRIPTION
- Change `chrom` to `chrome` for correct browser detecting.