### PR TITLE
fix bug casued by typo for `isTablet` in `BrowserDetect.php`

### DIFF
--- a/src/Stages/BrowserDetect.php
+++ b/src/Stages/BrowserDetect.php
@@ -39,7 +39,7 @@ class BrowserDetect implements StageInterface
         if (strpos($payload->getAgent(), 'Prerender') !== false) {
             $payload->setValue('isBot', true);
             $payload->setValue('isMobile', false);
-            $payload->setValue('isTable', false);
+            $payload->setValue('isTablet', false);
             $payload->setValue('isDesktop', true);
         }
 
@@ -50,7 +50,7 @@ class BrowserDetect implements StageInterface
         ) {
             $payload->setValue('isBot', true);
             $payload->setValue('isMobile', true);
-            $payload->setValue('isTable', false);
+            $payload->setValue('isTablet', false);
             $payload->setValue('isDesktop', false);
         }
 


### PR DESCRIPTION
in `src/Stages/BrowserDetect.php` there is a typo in 2 places (lines 42 and 53)
```php
$payload->setValue('isTable', false);
```
this fixes it