### PR TITLE
chore: exclude composer.lock using git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+composer.lock


### PR DESCRIPTION
#235 